### PR TITLE
JsonHttpRequestHttpResponseBiConsumer no-content response support

### DIFF
--- a/src/main/java/walkingkooka/net/http/json/JsonHttpRequestHttpResponseBiConsumer.java
+++ b/src/main/java/walkingkooka/net/http/json/JsonHttpRequestHttpResponseBiConsumer.java
@@ -69,19 +69,25 @@ final class JsonHttpRequestHttpResponseBiConsumer implements BiConsumer<HttpRequ
 
             if (null != json) {
                 final JsonNode output = this.handler.apply(json);
-
+                final boolean noContent = null == output;
                 response.addEntity(
                         this.post.apply(
-                                HttpEntity.EMPTY
-                                        .addHeader(
-                                                HttpHeaderName.CONTENT_TYPE,
-                                                MediaType.APPLICATION_JSON.setCharset(selectCharsetName(request))
-                                        )
-                                        .setBodyText(output.toString())
-                                        .setContentLength()
+                                noContent ?
+                                        HttpEntity.EMPTY :
+                                        HttpEntity.EMPTY
+                                                .addHeader(
+                                                        HttpHeaderName.CONTENT_TYPE,
+                                                        MediaType.APPLICATION_JSON.setCharset(selectCharsetName(request))
+                                                )
+                                                .setBodyText(noContent ? "" : output.toString())
+                                                .setContentLength()
                         )
                 );
-                response.setStatus(HttpStatusCode.OK.status());
+                response.setStatus(
+                        noContent ?
+                                HttpStatusCode.NO_CONTENT.status() :
+                                HttpStatusCode.OK.status()
+                );
             }
         }
     }

--- a/src/test/java/walkingkooka/net/http/json/JsonHttpRequestHttpResponseBiConsumerTest.java
+++ b/src/test/java/walkingkooka/net/http/json/JsonHttpRequestHttpResponseBiConsumerTest.java
@@ -203,6 +203,32 @@ public final class JsonHttpRequestHttpResponseBiConsumerTest implements ToString
         assertEquals(expected, response, () -> "response\n" + request);
     }
 
+    @Test
+    public void testSuccessNoContent() {
+        final CharsetName charsetName = CharsetName.UTF_16;
+
+        final HttpRequest request = this.request(
+                HttpEntity.EMPTY
+                        .addHeader(HttpHeaderName.ACCEPT_CHARSET, AcceptCharset.parse(charsetName.toHeaderText()))
+                        .setBodyText(INPUT.toString())
+                        .setContentLength()
+        );
+
+        final HttpResponse response = HttpResponses.recording();
+
+        JsonHttpRequestHttpResponseBiConsumer.with((inputIgnored) -> null, POST)
+                .accept(request, response);
+
+        final HttpResponse expected = HttpResponses.recording();
+        expected.setStatus(HttpStatusCode.NO_CONTENT.status());
+        expected.addEntity(
+                HttpEntity.EMPTY
+                        .addHeader(POST_HEADER_NAME, POST_HEADER_VALUE)
+        );
+
+        assertEquals(expected, response, () -> "response\n" + request);
+    }
+
     private JsonHttpRequestHttpResponseBiConsumer createConsumer() {
         return JsonHttpRequestHttpResponseBiConsumer.with(HANDLER, POST);
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net-http-json/issues/27
- JsonHttpRequestHttpResponseBiConsumer should return NO-CONTENT if null returned